### PR TITLE
allow to ignore vulnerabilities by sonatype id or cve id

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,7 +5,7 @@
 - Add `--reset-cache` to delete cached vulnerability data.
 - Add `--ignore-cache` to temporarily ignore cached vulnerability data.
 - Handle invalid JSON caches (by ignoring/overwriting them)
-
+- Allow to ignore vulnerabilities by Sonatype ID or CVE ID 
 
 ## 0.5.0
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Options:
   --token TEXT         Token for authentication.
   --column TEXT        Column to show (can be specified multiple times).
                        [default: name, version, title]
-  --ignore-id TEXT     Ignore a vulnerability by ID (can be specified multiple
+  --ignore-id TEXT     Ignore a vulnerability by Sonatype ID or CVE (can be specified multiple
                        times).
   --help               Show this message and exit.
 ```
@@ -91,7 +91,7 @@ token = string
 # Supported: id, name, version, cve, cvss_score, title, description
 columns = name, version, title
 
-# Optional: comman-separated list of vulnerability IDs to ignore.
+# Optional: comman-separated list of vulnerability IDs (Sonatype ID or CVE) to ignore.
 ignore-ids = x,y,z
 ```
 

--- a/ossaudit/cli.py
+++ b/ossaudit/cli.py
@@ -52,7 +52,7 @@ from . import audit, cache, option, packages
     "--ignore-id",
     "ignore_ids",
     multiple=True,
-    help="Ignore a vulnerability by ID (can be specified multiple times).",
+    help="Ignore a vulnerability by Sonatype ID or CVE (can be specified multiple times).",
 )
 @option.add(
     "--ignore-cache",
@@ -86,7 +86,7 @@ def cli(
     try:
         vulns = [
             v for v in audit.components(pkgs, username, token, ignore_cache)
-            if v.id not in ignore_ids
+            if v.id not in ignore_ids and v.cve not in ignore_ids
         ]
     except audit.AuditError as e:
         raise click.ClickException(str(e))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -145,24 +145,29 @@ class TestCli(PatchedTestCase):
             Vulnerability(id="0"),
             Vulnerability(id="1"),
             Vulnerability(id="2"),
-            Vulnerability(id="10"),
-            Vulnerability(id="20"),
+            Vulnerability(id="10", cve="CVE-10"),
+            Vulnerability(id="20", cve="CVE-20"),
+            Vulnerability(id="30", cve="CVE-30"),
+            Vulnerability(id="31", cve="CVE-31"),
+            Vulnerability(cve="CVE-32"),
         ]
 
         with patch("ossaudit.packages.get_installed"):
             with patch("ossaudit.audit.components") as components:
                 components.return_value = vulns
                 runner = CliRunner()
-                args = ["--installed", "--ignore-id", "1", "--ignore-id", "20"]
+                args = ["--installed", "--ignore-id", "1", "--ignore-id", "20", "--ignore-id", "CVE-30"]
                 result = runner.invoke(cli.cli, args)
                 self.assertNotEqual(result.exit_code, 0)
-                self.assertTrue("3 vulnerabilities" in result.output)
+                self.assertTrue("5 vulnerabilities" in result.output)
 
     def test_ignore_all_ids_arg(self) -> None:
         vulns = [
             Vulnerability(id="0"),
             Vulnerability(id="1"),
-            Vulnerability(id="2"),
+            Vulnerability(id="2", cve="CVE-2"),
+            Vulnerability(id="3", cve="CVE-3"),
+            Vulnerability(cve="CVE-4")
         ]
 
         with patch("ossaudit.packages.get_installed"):
@@ -177,6 +182,10 @@ class TestCli(PatchedTestCase):
                     "1",
                     "--ignore-id",
                     "2",
+                    "--ignore-id",
+                    "CVE-3",
+                    "--ignore-id",
+                    "CVE-4"
                 ]
                 result = runner.invoke(cli.cli, args)
                 self.assertEqual(result.exit_code, 0)


### PR DESCRIPTION
this patch improves the ignore-id parameter to allow setting CVE ids too in addition to the Sonatype ID.
Furthermore the documentation is updated that "id" means the Sonatype id of a vulnerability.

As a lot of other scanners accept CVE ids for whitelisting (even other scanner using Sonatype OSSIndex for other languages) this functionality was added here too. The old implementation was misleading as it was not documented that the id to ignore is not the wildly used and everywhere (throughout the internet) documented CVE id but the proprietary Sonatype one. The default output of ossaudit was not showing the Sonatype ID too, only the CVE  (within the title field - if available)

Thanks,
S. Seide