### PR TITLE
add all fields returned from ossindex scan as possible column

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,18 @@ Options:
   --help               Show this message and exit.
 ```
 
+Possible column names are:
+* name (python package name)
+* version (python package version)
+* coordinate
+* id
+* cve (optional, might be emtpy)
+* cvss_score
+* cvss_vector
+* short_title
+* title
+* description
+* reference (url with further information on ossindex website)
 
 ## Configuration
 

--- a/ossaudit/audit.py
+++ b/ossaudit/audit.py
@@ -14,11 +14,16 @@ Vulnerability = namedtuple(
     "Vulnerability", [
         "name",
         "version",
+        "coordinate",
         "id",
         "cve",
         "cvss_score",
+        "cvss_vector",
+        "short_title",
         "title",
         "description",
+        "reference",
+        "external_references"
     ]
 )
 
@@ -88,8 +93,13 @@ def _transform(pkg: packages.Package, vuln: Dict) -> Vulnerability:
         name=pkg.name,
         version=pkg.version,
         id=vuln.get("id", ""),
+        coordinate=pkg.coordinate,
+        short_title=vuln.get("displayName", ""),
         cve=vuln.get("cve", ""),
         cvss_score=vuln.get("cvssScore", ""),
+        cvss_vector=vuln.get("cvssVector", ""),
         title=vuln.get("title", ""),
         description=vuln.get("description", ""),
+        reference=vuln.get("reference", ""),
+        external_references=vuln.get("externalReferences", [])
     )


### PR DESCRIPTION
This PR adds all other fields available at OSSIndex db to the list of possible output columns.
The default columns are not changed.

The list with external references is added here too to the internal data structure to allow json output with it in the future.
