### PR TITLE
add two new json output formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,10 @@ Options:
                        specified multiple times).
   --ignore-cache       Temporarily ignore existing cache.
   --reset-cache        Remove existing cache.
-  --help               Show this message and exit.
+  --json               Output vulnerabilities as json list
+  --json-full          Output all dependencies found and their vulnerabilities
+                       as json list (columns given are ignored)
+   --help               Show this message and exit.
 ```
 
 

--- a/ossaudit/audit.py
+++ b/ossaudit/audit.py
@@ -38,11 +38,16 @@ def components(
         p for p in pkgs
         if not any(p.coordinate == o.coordinate for o, _ in old)
     ], ignore_cache, username, token))  # yapf: disable
+    return (new + old)
+
+
+def flatten_vuln_list(vulns):
     return [
         _transform(p, vuln)
-        for p, e in new + old
-        for vuln in e.get("vulnerabilities", [])
+        for p, c in vulns       # package, coordinate from ossindex
+        for vuln in c.get("vulnerabilities", [])
     ]
+
 
 
 def _from_api(
@@ -93,3 +98,44 @@ def _transform(pkg: packages.Package, vuln: Dict) -> Vulnerability:
         title=vuln.get("title", ""),
         description=vuln.get("description", ""),
     )
+
+
+def create_report(vulns: List):
+    """Create a list of dict objects as returned by the SonarType OSSIndex scanner. The list contains on
+    dict per python package found and queried against the database. The packages "vulnerabilities" field
+    is an list with all vulnerabilites for this package. The vulnerability list can be empty.
+
+    Parameters
+    ----------
+    vulns : List with a tuple of the package object and the SonarType response for this package
+
+    Returns
+    -------
+    list - a list of scan coordinates (packages) and a list with their vulnerabilities (if any)
+    """
+    out_list = []
+    for p, c in vulns:
+        del c["time"]
+        out_list.append(c)
+    return out_list
+
+def create_vuln_list(vulns: List, columns: List):
+    """Create a list of dicts from the vulnerability tuples containing only the column names requests
+
+    Parameters
+    ----------
+    vulns : List list of all vulnerabilities found
+    columns : List list of all columns(fields) needed from the vulnerability for output
+
+    Returns
+    -------
+    list - a list of vulnerability dictionaries containing the columns given only
+    """
+    out_list = []
+    for v in vulns:
+        v_dict = v._asdict()
+        v_out = {}
+        for c in columns:
+            v_out[c] = v_dict[c] if c in v_dict else ""
+        out_list.append(v_out)
+    return out_list

--- a/ossaudit/cli.py
+++ b/ossaudit/cli.py
@@ -4,6 +4,7 @@
 
 import shutil
 import sys
+import json as JSON
 from typing import IO, List, Tuple
 
 import click
@@ -67,6 +68,16 @@ from . import audit, cache, option, packages
     is_flag=True,
     help="Remove existing cache.",
 )
+@option.add(
+    "--json",
+    is_flag=True,
+    help="Output vulnerabilities as json list",
+)
+@option.add(
+    "--json-full",
+    is_flag=True,
+    help="Output all dependencies found and their vulnerabilities as json list (columns given are ignored)",
+)
 def cli(
         installed: bool,
         files: List[IO[str]],
@@ -76,6 +87,8 @@ def cli(
         ignore_ids: Tuple[str],
         ignore_cache: bool,
         reset_cache: bool,
+        json: bool,
+        json_full: bool
 ) -> None:
     if reset_cache:
         cache.reset()
@@ -87,23 +100,35 @@ def cli(
         pkgs += packages.get_from_files(files)
 
     try:
+        all_coordinates = audit.components(pkgs, username, token, ignore_cache)
+
+        # only write full coordinate report to stdout and exit afterwards
+        if json_full:
+            print(JSON.dumps(audit.create_report(all_coordinates)))#
+            plen = len(list(c for p, c in all_coordinates if "vulnerabilities" in c and len(c["vulnerabilities"]) > 0))
+            sys.exit(plen)
+
+        # flatten list with package coordinates and their vulnerabilities into a vulnerability list only
         vulns = [
-            v for v in audit.components(pkgs, username, token, ignore_cache)
+            v for v in audit.flatten_vuln_list(all_coordinates)
             if v.id not in ignore_ids and v.cve not in ignore_ids
         ]
     except audit.AuditError as e:
         raise click.ClickException(str(e))
 
     if vulns:
-        size = shutil.get_terminal_size()
-        table = texttable.Texttable(max_width=size.columns)
-        table.header(columns)
-        table.set_cols_dtype(["t" for _ in range(len(columns))])
-        table.add_rows([[getattr(v, c.lower(), "")
-                         for c in columns]
-                        for v in vulns], False)
-        click.echo(table.draw())
+        vlen, plen = len(vulns), len(pkgs)
+        if json:
+            print(JSON.dumps(audit.create_vuln_list(vulns, columns)))
+        else:
+            size = shutil.get_terminal_size()
+            table = texttable.Texttable(max_width=size.columns)
+            table.header(columns)
+            table.set_cols_dtype(["t" for _ in range(len(columns))])
+            table.add_rows([[getattr(v, c.lower(), "")
+                             for c in columns]
+                            for v in vulns], False)
+            click.echo(table.draw())
+            click.echo("Found {} vulnerabilities in {} packages".format(vlen, plen))
 
-    vlen, plen = len(vulns), len(pkgs)
-    click.echo("Found {} vulnerabilities in {} packages".format(vlen, plen))
-    sys.exit(vlen != 0)
+        sys.exit(vlen != 0)


### PR DESCRIPTION
Currently a text output is available only.
This PR adds two new cli parameter to select different json formatted outputs too, making it easier to pre-process the results with other tools.

1) `--json` uses the columns defined by `--column` param and writes a list of json objects instead of the text table
2) `--json-full` writes the ouput as received from the Sonartype OSSIndex db. This output matches the output from other scanners like `auditjs` for NodeJS. It contains a list with all dependencies found and their respective vulnerabilities giving the caller a change to get a list of all libraries used too (wether vulnerable or not).

This PR works together with my other PR (return additional fields) or as stand-alone update...

Shortened example running `ossaudit --column name --column version --column id --json`
```json
[
  {
    "name": "django",
    "version": "3.2.1",
    "id": "c7129ff8-08bc-4afe-82ec-7d97b9491741"
  },
  {
    "name": "django",
    "version": "3.2.1",
    "id": "8da39da0-08b9-4c94-92a5-f397bf7cc000"
  },
  ...
]
```

Shortened example running with full output: `ossaudit --json-full`
```json
[
  {
    "coordinates": "pkg:pypi/appdirs@1.4.4",
    "description": "\"A small Python module for determining appropriate \"\" +         \"\"platform-specific dirs, e.g. a \"\"user data dir\"\".\"",
    "reference": "https://ossindex.sonatype.org/component/pkg:pypi/appdirs@1.4.4?utm_source=python-requests&utm_medium=integration&utm_content=2.21.0",
    "vulnerabilities": []
  },
  {
    "coordinates": "pkg:pypi/django@3.2.1",
    "reference": "https://ossindex.sonatype.org/component/pkg:pypi/django@3.2.1?utm_source=python-requests&utm_medium=integration&utm_content=2.25.1",
    "vulnerabilities": [
      {
        "id": "c7129ff8-08bc-4afe-82ec-7d97b9491741",
        "displayName": "CVE-2021-33203",
        "title": "[CVE-2021-33203] Django before 2.2.24, 3.x before 3.1.12, and 3.2.x before 3.2.4 has a potential ...",
        "description": "Django before 2.2.24, 3.x before 3.1.12, and 3.2.x before 3.2.4 has a potential directory traversal via django.contrib.admindocs. Staff members could use the TemplateDetailView view to check the existence of arbitrary files. Additionally, if (and only if) the default admindocs templates have been customized by application developers to also show file contents, then not only the existence but also the file contents would have been exposed. In other words, there is directory traversal outside of the template root directories.",
        "cvssScore": 7.5,
        "cvssVector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
        "cve": "CVE-2021-33203",
        "reference": "https://ossindex.sonatype.org/vulnerability/c7129ff8-08bc-4afe-82ec-7d97b9491741?component-type=pypi&component-name=django&utm_source=python-requests&utm_medium=integration&utm_content=2.25.1",
        "externalReferences": [
          "https://nvd.nist.gov/vuln/detail/CVE-2021-33203"
        ]
      },
      {
        "id": "8da39da0-08b9-4c94-92a5-f397bf7cc000",
        "displayName": "CVE-2021-33571",
        "title": "[CVE-2021-33571] In Django 2.2 before 2.2.24, 3.x before 3.1.12, and 3.2 before 3.2.4, URLValidat...",
        "description": "In Django 2.2 before 2.2.24, 3.x before 3.1.12, and 3.2 before 3.2.4, URLValidator, validate_ipv4_address, and validate_ipv46_address do not prohibit leading zero characters in octal literals. This may allow a bypass of access control that is based on IP addresses. (validate_ipv4_address and validate_ipv46_address are unaffected with Python 3.9.5+..) .",
        "cvssScore": 7.5,
        "cvssVector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
        "cve": "CVE-2021-33571",
        "reference": "https://ossindex.sonatype.org/vulnerability/8da39da0-08b9-4c94-92a5-f397bf7cc000?component-type=pypi&component-name=django&utm_source=python-requests&utm_medium=integration&utm_content=2.25.1",
        "externalReferences": [
          "https://nvd.nist.gov/vuln/detail/CVE-2021-33571"
        ]
      }
    ]
  },
  ...
```